### PR TITLE
Fixed

### DIFF
--- a/src/components/DashboardV2/PatientDashboard/Assessment/FamilyHistory/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/FamilyHistory/index.js
@@ -37,49 +37,49 @@ const questions = [
         label: "Pregnancies",
         name: "pregnancies",
         selectName: "pregnancies_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Miscarriages",
         name: "miscarriages",
         selectName: "miscarriages_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Abortions",
         name: "abortions",
         selectName: "abortions_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Living children",
         name: "living_children",
         selectName: "living_children_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Vaginal deliveries",
         name: "vaginal_deliveries",
         selectName: "vaginal_deliveries_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Caeseran",
         name: "caeserean",
         selectName: "caeserean_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Term births",
         name: "term_births",
         selectName: "term_births_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
       {
         label: "Premature birth",
         name: "premature_birth",
         selectName: "premature_birth_select",
-        selectOptions: Array.from({ length: 30 }, (_, i) => 0 + i),
+        selectOptions: Array.from({ length: 30 }, (_, i) => 1 + i),
       },
     ],
   },
@@ -476,7 +476,7 @@ const PersonalAndFamilyHistory = ({ onComplete }) => {
         patientPersonalFamilyInfo.obstetricHistory.forEach((item) => {
           const key = item.name.toLowerCase().replace(/\s+/g, '_');
           // Set the checkbox state
-          mapped[key] = item.level !== null && item.level !== undefined;
+          mapped[key] = item.level !== null && item.level !== undefined && item.level > 0;
           // Set the select value with the correct selectName format
           mapped[`${key}_select`] = item.level;
         });

--- a/src/components/DashboardV2/PatientDashboard/Assessment/HealthAndMedicalHistory/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/HealthAndMedicalHistory/index.js
@@ -377,17 +377,28 @@ const HealthAndMedicalHistory = ({ onComplete }) => {
         return null;
       };
       const prefillAnswers = {
-        overll_wellbeing: lifestyle.howWellThingsGoingOverall || 1,
+        overll_wellbeing: lifestyle.howWellThingsGoingOverall ?? 1,
+        overll_wellbeing_na: lifestyle.howWellThingsGoingOverall === 0, 
         school_wellbeing: lifestyle.howWellThingsGoingSchool || 1,
+        school_wellbeing_na: lifestyle.howWellThingsGoingSchool === 0,
         job_wellbeing: lifestyle.howWellThingsGoingJob || 1,
+        job_wellbeing_na: lifestyle.howWellThingsGoingJob === 0,  
         social_life_wellbeing: lifestyle.howWellThingsGoingSocialLife || 1,
+        social_life_wellbeing_na: lifestyle.howWellThingsGoingSocialLife === 0,
         close_friends_wellbeing: lifestyle.howWellThingsGoingCloseFriends || 1,
+        close_friends_wellbeing_na: lifestyle.howWellThingsGoingCloseFriends === 0,
         sex_wellbeing: lifestyle.howWellThingsGoingSex || 1,
+        sex_wellbeing_na: lifestyle.howWellThingsGoingSex === 0,
         attitude_wellbeing: lifestyle.howWellThingsGoingAttitude || 1,
+        attitude_wellbeing_na: lifestyle.howWellThingsGoingAttitude === 0,
         relationship_wellbeing: lifestyle.howWellThingsGoingPartner || 1,
+        relationship_wellbeing_na: lifestyle.howWellThingsGoingPartner === 0,
         children_wellbeing: lifestyle.howWellThingsGoingKids || 1,
+        children_wellbeing_na: lifestyle.howWellThingsGoingKids === 0,
         parents_wellbeing: lifestyle.howWellThingsGoingParents || 1,
+        parents_wellbeing_na: lifestyle.howWellThingsGoingParents === 0,
         spouse_wellbeing: lifestyle.howWellThingsGoingSpouse || 1,
+        spouse_wellbeing_na: lifestyle.howWellThingsGoingSpouse === 0,
         mode_of_own_birth: lifestyle.howWereYouBorn,
         birth_complications: normalizeYesNo(lifestyle.wereYouBornWithComplication?.yesNo),
         birth_complications_details: lifestyle.wereYouBornWithComplication?.describe || "",
@@ -552,7 +563,7 @@ const HealthAndMedicalHistory = ({ onComplete }) => {
       Object.keys(patientHealthMedicalInfo.obj).length > 0
     ) {
       const transformedAnswers = transformApiDataToAnswers(patientHealthMedicalInfo);
-      console.log("Prefilling from API:", transformedAnswers);
+
       setAnswers(transformedAnswers);
       setCurrentQuestionIndex(0);
       // Clear localStorage to avoid confusion
@@ -579,7 +590,7 @@ const HealthAndMedicalHistory = ({ onComplete }) => {
     switch (question.type) { 
       case "rating_scale": {
         const value = answers[question.name];
-        if (value === undefined || value === null || value === 0) {
+        if (value === undefined || value === null) {
           return false;
         }
         return true;

--- a/src/components/DashboardV2/PatientDashboard/Assessment/Nutrition/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/Nutrition/index.js
@@ -41,6 +41,7 @@ const questions = [
       "No Wheat",
       "Gluten Free",
       "Other",
+      "None",
     ],
   },
   {
@@ -84,6 +85,7 @@ const questions = [
       "Preservatives",
       "Food coloring",
       "Other",
+      "None"
     ],
   },
   {
@@ -193,7 +195,7 @@ const questions = [
   {
     question: "Please record what you eat in a typical day:",
     type: "long_textarea",
-    sub: "Fluids",
+    sub: "Drink",
     name: "diet_detail_fluids",
   },
   {
@@ -277,19 +279,19 @@ const questions = [
         question: "If yes, check amount:",
         type: "radio",
         name: "coffee_amount",
-        options: ["1", "2-4", "More than 4"],
+        options: ["1", "2-4", "More than 4", "none"],
         label: "Coffee (cups per day)",
       },
       {
         type: "radio",
         name: "tea_amount",
-        options: ["1", "2-4", "More than 4"],
+        options: ["1", "2-4", "More than 4", "None"],
         label: "Tea (cups per day)",
       },
       {
         type: "radio",
         name: "soda_amount",
-        options: ["1", "2-4", "More than 4"],
+        options: ["1", "2-4", "More than 4", "None"],
         label: "Caffeinated sodas—regular or diet (cans per day)",
       },
     ],
@@ -424,8 +426,7 @@ const Nutrition = ({ onComplete }) => {
     switch (question.type) {
       case "long_select": {
         const value = answers[question.name];
-        console.log("value--", value);
-        if (value === undefined || value === null || value === "" || value === 0) {
+        if (value === undefined || value === null || value === "") {
           console.log(`Validation Failed: No value selected for ${question.name}`);
           return false;
         }

--- a/src/components/DashboardV2/PatientDashboard/Assessment/Substance_Use/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/Substance_Use/index.js
@@ -371,7 +371,7 @@ const SubstanceUse = ({ onComplete }) => {
       exposedTo2ndSmoke: answers.exposed_to_second_hand_smoke === "Yes",
       howManyAlcoholWeek: answers.exposed_to_smoke || "",
       previousAlcoholIntake: {
-        yesNo: answers.alcohol_problem === "Yes",
+        yesNo: answers.previous_alcohol_intake === "Yes",
         describe:answers.previous_packs_per_day || "",
       },
       problemAlcohol: answers.alcohol_problem === "Yes",


### PR DESCRIPTION
Fixed: 
**Health & Medical History:-** 
When selecting “N/A” it doesn’t allow me to “Save & Continue” to go to the next question for multiple questions
Get the value 0 in API and show the N/A checkbox Selected

**Substance Use:** 
Find the bug to get API data is not correct 

**Nutrition & Dietary Habits:**
- None” needs to be an option.
   - Do you currently follow any of the following special diets or nutritional programs
   - Do you adversely react to: (Check all that apply)
- 
- Check wording “eat” and “Fluids” do they go together? Maybe replace “eat” with “drink”
- fixed validation when we select the value 0   
-  There should be a “none” option for each section

**Family History:**

-  fixed the first question to show right checkbox if value available
-  and remove 0 option for first question input

**Reproductive Form:**
 When 0 is selected in the input, the 'Color' and 'Severity' options should be disabled and their values should be cleared. Also, ensure that validation is skipped for this condition.
