### PR TITLE
Fixed

### DIFF
--- a/src/components/DashboardV2/PatientDashboard/Assessment/Nutrition/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/Nutrition/index.js
@@ -311,10 +311,18 @@ const questions = [
   },
   {
     question: "When you drink caffeine do you feel:",
-    type: "radio",
+    type: "checkbox",
     name: "sensitive_food_caffeine_feel",
-    options: ["Irritable or weird", "Aches or pains"],
-  },
+    options: ["Irritable or weird", "Aches or pains", "Other"],
+    subQuestions: [
+      {
+        question: "Other",
+        type: "text",
+        name: "sensitive_food_caffeine_feel_other"
+      }
+    ]
+  }
+  
 ];
 
 const Nutrition = ({ onComplete }) => {
@@ -371,6 +379,7 @@ const Nutrition = ({ onComplete }) => {
       soda_amount: info.sodaCups || "",
       sensitive_food_caffeine: normalizeYesNo(info.adverseReactionToCoffee?.yesNo),
       sensitive_food_caffeine_feel: info.reactionToCaffeine || "",
+      sensitive_food_caffeine_feel_other: info.sensitiveCaffeineOther || "",
       breakfast_time: info.breakfastTime || "",
       lunch_time: info.lunchTime || "",
       snack_time: info.snacksTime || "",
@@ -594,6 +603,7 @@ const Nutrition = ({ onComplete }) => {
       },
       explainAdverseReactionToCoffee: answers.sensitive_food_caffeine_other || "",
       reactionToCaffeine: answers.sensitive_food_caffeine_feel || "",
+      sensitiveCaffeineOther: answers.sensitive_food_caffeine_feel_other || "",
       specialDietReason:answers.special_diet_reason || "",
       breakfastTime:answers.breakfast_time || "",
       lunchTime:answers.lunch_time || "",
@@ -724,42 +734,40 @@ const Nutrition = ({ onComplete }) => {
       case "checkbox":
         return (
           <Checkbox.Group
-            name={question.name}
-            onChange={(checkedValues) =>
-              handleChange(checkedValues, question.name)
-            }
-            value={answers[question.name] || []}
-            className="checkbox-group"
-          >
-            {question.options.map((option, index) => (
-              <Checkbox key={index} value={option} className="checkbox-item">
-                {option === "Other" ? (
-                  <>
-                    {option}
-                    {answers[question.name] &&
-                      answers[question.name].includes("Other") && (
-                        <>
-                          <br />
-                          <Input
-                            className="input_questtionnaire"
-                            placeholder="Please specify"
-                            value={answers[`${question.name}_other`] || ""}
-                            onChange={(e) =>
-                              handleChange(
-                                e.target.value,
-                                `${question.name}_other`,
-                              )
-                            }
-                          />
-                        </>
-                      )}
-                  </>
-                ) : (
-                  option
-                )}
-              </Checkbox>
-            ))}
-          </Checkbox.Group>
+          name={question.name}
+          onChange={(checkedValues) =>
+            handleChange(checkedValues, question.name)
+          }
+          value={answers[question.name] || []}
+          className="checkbox-group"
+        >
+          {question.options.map((option, index) => (
+            <Checkbox key={index} value={option} className="checkbox-item">
+              {option === "Other" ? (
+                <>
+                  {option}
+                  {answers[question.name] &&
+                    answers[question.name].includes("Other") && (
+                      <>
+                        <br />
+                        <Input
+                          className="input_questtionnaire"
+                          placeholder="Please describe"
+                          value={answers[`${question.name}_other`] || ""}
+                          onChange={(e) =>
+                            handleChange(e.target.value, `${question.name}_other`)
+                          }
+                          style={{ marginTop: "10px" }}
+                        />
+                      </>
+                    )}
+                </>
+              ) : (
+                option
+              )}
+            </Checkbox>
+          ))}
+        </Checkbox.Group>        
         );
       
         case "radiowithselect":

--- a/src/components/DashboardV2/PatientDashboard/Assessment/ReproductiveHealth/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/ReproductiveHealth/index.js
@@ -792,7 +792,8 @@ console.log(setisDisabled);
             
               const controllingField = skipValidationMap[subQuestion.name];
               const controllingValue = answers[controllingField];
-              const skip = controllingValue === 0 || controllingValue === "0";
+              const skip = controllingValue === 0 || controllingValue === "0" || answers[`${controllingField}_unsure`] === true;
+
             
               if (!subAnswer && !skip) {
                 subQuestionsValid = false;
@@ -849,6 +850,31 @@ console.log(setisDisabled);
 
   const handleChange = (value, name) => {
     let updatedAnswers = { ...answers };
+    // Handle disabling of color/severity when unsure is selected
+    if (name.endsWith("_unsure") && value === true) {
+      const baseName = name.replace("_unsure", "");
+
+      // These are the corresponding fields to disable/clear
+      const relatedDisables = {
+        cervical_mucus: "cervical_mucus_sub",
+        Watery_mucus_sub: "Watery_mucus_colour",
+        egg_white_mucus_sub: "egg_white_mucus_colour",
+        pre_spotting_sub: "pre_spotting_colour",
+        after_period_spot_sub: "after_period_spot_colour",
+        duration_per_cycle_pelvic_pain: "duration_per_cycle_severity_pelvic_pain",
+        duration_per_cycle_pp_not_menstrual: "duration_per_mild_cycle_severity_pp_not_menstrual",
+        pms_sympton_check: "pms_sympton_severity",
+        cycle_spotting_sub_number: "cycle_spotting_sub",
+        intercourse_during_fertile_sub: null, // Optional: for completeness
+      };
+
+      const relatedField = relatedDisables[baseName];
+      if (relatedField) {
+        updatedAnswers[relatedField] = "";
+        setDisabledSeverity((prev) => ({ ...prev, [relatedField]: true }));
+      }
+    }
+
     if (
       name === "duration_per_cycle_pelvic_pain" ||
       name === "duration_per_cycle_pp_not_menstrual" ||

--- a/src/components/DashboardV2/PatientDashboard/Assessment/Substance_Use/index.js
+++ b/src/components/DashboardV2/PatientDashboard/Assessment/Substance_Use/index.js
@@ -614,16 +614,13 @@ const SubstanceUse = ({ onComplete }) => {
 
   const progressColor =
     currentQuestionIndex === totalQuestions - 1 ? "#01ACEE" : "#C2E6F8";
-  const progressPercentage =
-    ((currentQuestionIndex + 1) / totalQuestions) * 100;
-
-    const percentProgressBar = Math.round(100/totalQuestions);
+    const progressPercent = Math.round((currentQuestionIndex / (totalQuestions - 1)) * 100);
   return (
     <Row gutter={16} style={{ padding: "0 5%" }}>
       <Col xs={24} sm={24} md={24} lg={24} xl={24}>
         <FormWrapper name="FEMALE INTAKE QUESTIONNAIRE" />
         <Progress
-          percent={Math.round(progressPercentage)- percentProgressBar}
+          percent={progressPercent}
           strokeColor={progressColor}
         />
         <h3 style={{ margin: "20px 0", fontSize:"15px", fontWeight:"600", color: "#F2AA93" }}>


### PR DESCRIPTION
Fixed: 
**Reproductive Form:**
- When "Unsure" is selected, the color and severity options will be disabled, and corresponding data will be cleared.
- Validation has been updated to bypass checks when "Unsure" is selected.

**Substance Use Form:**
- Resolved a bug where the progress bar did not display 100% upon completing the final question.

**Nutrition Form:**

- For the question "When you drink caffeine, how do you feel?", users can now:
- Select multiple options simultaneously.
- Enter a custom "Other" response.
- A new key has been added in the backend to support storing and retrieving the "Other" input data.
